### PR TITLE
Add category to Command Palette actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,12 +159,14 @@
             {
                 "command": "hex-casting.copySelectionAsBBCode",
                 "title": "Copy Selection as BBCode",
-                "enablement": "editorLangId == hexcasting && editorHasSelection && !editorHasMultipleSelections"
+                "enablement": "editorLangId == hexcasting && editorHasSelection && !editorHasMultipleSelections",
+                "category": "Hex Casting"
             },
             {
                 "command": "hex-casting.copySelectionAsList",
                 "title": "Copy Selection as List",
-                "enablement": "editorLangId == hexcasting && editorHasSelection && !editorHasMultipleSelections"
+                "enablement": "editorLangId == hexcasting && editorHasSelection && !editorHasMultipleSelections",
+                "category": "Hex Casting"
             }
         ],
         "menus": {


### PR DESCRIPTION
This matches the style of most other extensions, and allows searching for Hex Casting commands in the palette without having to remember their names.

![Example of image](https://github.com/object-Object/vscode-hex-casting/assets/49845522/8e922618-78c0-4947-8c6e-2f97fe2df939)
